### PR TITLE
main の変更を取り込み、Lambda ルーティングの競合を解消

### DIFF
--- a/infra/lambda/src/index.ts
+++ b/infra/lambda/src/index.ts
@@ -31,8 +31,15 @@ export const handler = async (
       return handlePostRecipe(event);
     }
 
+    // GET /recipes - Temporary placeholder response merged from main branch
+    if (rawPath === '/recipes' && httpMethod === 'GET') {
+      return {
+        statusCode: 501,
+        body: JSON.stringify({ message: 'GET /recipes is not implemented yet' }),
+      };
+    }
+
     // TODO: Add routing logic for other endpoints
-    // - GET /recipes
     // - GET /recipes/{recipeId}
     // - PUT /recipes/{recipeId}
     // - /menus


### PR DESCRIPTION
### Motivation
- main 側のルーティング追加を work に反映し、API ハンドラでの競合を解消して動作を一貫させるため。 
- `/recipes` の POST ハンドラと main 側の GET 暫定ルートを両立させ、今後の実装作業を進めやすくするため。

### Description
- `infra/lambda/src/index.ts` の競合を解消し、`/health`、`POST /recipes`（既存の `handlePostRecipe` を使用）、および `GET /recipes`（501 暫定レスポンス）を順序立てて配置しました。 
- 競合マーカーを除去してルーティングの TODO コメントを整理し、未実装エンドポイントの一覧を明確にしました。 
- 競合解消分のみを反映し、他のファイルは変更していません。

### Testing
- main 側の変更を取り込んだ際にルーティングの競合が発生することを確認し、該当箇所を修正して反映しました（競合解消は成功）。
- `npm --prefix infra/lambda run build` を実行したところ、`uuid` モジュールに関する型解決エラーによりビルドは失敗しました（依存解決不足）。
- `npm --prefix infra/lambda ci` を実行したところ、npm レジストリへのアクセスで 403 が返され依存のインストールに失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f37fa9a088331ac8f78f6b40e9e4c)