### PR TITLE
CI ワークフロー一覧とバックエンドデプロイ概要を更新

### DIFF
--- a/docs/docs/deployment/backend.md
+++ b/docs/docs/deployment/backend.md
@@ -6,15 +6,15 @@ sidebar_position: 3
 
 ## 概要
 
-バックエンド（Lambda + API Gateway）およびインフラ（DynamoDB、Cognito 等）は、将来的に AWS CDK で管理する方針とする。
-CDK アプリ実装完了後は、変更を `cdk deploy` コマンドでデプロイする運用を想定している。
-現時点では `infra/` 配下に CDK アプリ実装が存在しないため、このページの CDK 操作手順は実装完了後に有効となる予定である。
+バックエンド（Lambda + API Gateway）およびインフラ（DynamoDB、Cognito 等）は AWS CDK で管理する方針とする。
+変更は `cdk deploy` コマンドでデプロイする運用を想定している。
+
+`infra/lib/cooking-planner-stack.ts` に CDK スタックが実装されており、現時点では **DynamoDB テーブル**（Recipes / RecipeIngredients / Menus）が定義されている。
+Lambda・API Gateway・Cognito・S3+CloudFront などのリソースは今後の Issue で順次追加予定。
 
 ---
 
 ## 手動デプロイ手順
-
-> **TODO**: 以下の手順は `infra/` 配下の CDK アプリ実装完了後に利用する。
 
 ### 1. 差分確認
 
@@ -84,8 +84,8 @@ cdk deploy
 
 ---
 
-## 初回デプロイ（CDK スタック未作成時）
+## 初回デプロイ（CDK スタック未完成時）
 
-> **TODO**: CDK スタックの実装完了後に手順を追記する。
-> 現在 `infra/` 配下には CDK アプリ実装（`infra/lib` 等）はなく、Lambda コードと統合メモのみ存在する。
+> **TODO**: Lambda・API Gateway・Cognito・S3+CloudFront などのリソースが CDK スタックに追加され次第、手順を追記する。
+> 現在 `infra/lib/cooking-planner-stack.ts` には DynamoDB テーブルのみ定義されている。
 > 参考: `infra/CDK_INTEGRATION.md`

--- a/docs/docs/development/github-workflow.mdx
+++ b/docs/docs/development/github-workflow.mdx
@@ -74,14 +74,14 @@ GitHub Actions で以下のワークフローが自動実行されます。
 
 **トリガー**: `infra/**`（ただし `infra/lambda/**` を除く）に変更を含む push または PR（対象ブランチ: `main`, `develop`）
 
-| ステップ                 | コマンド               |
-| ------------------------ | ---------------------- |
-| 型チェック               | `npx tsc --noEmit`     |
-| Prettier                 | `npm run format:check` |
-| ESLint                   | `npm run lint`         |
-| ビルド                   | `npm run build`        |
-| CDK Synth（dev 環境）    | `npx cdk synth --context stage=dev --no-staging` |
-| CDK Synth（prod 環境）   | `npx cdk synth --context stage=prod --no-staging` |
+| ステップ               | コマンド                                          |
+| ---------------------- | ------------------------------------------------- |
+| 型チェック             | `npx tsc --noEmit`                                |
+| Prettier               | `npm run format:check`                            |
+| ESLint                 | `npm run lint`                                    |
+| ビルド                 | `npm run build`                                   |
+| CDK Synth（dev 環境）  | `npx cdk synth --context stage=dev --no-staging`  |
+| CDK Synth（prod 環境） | `npx cdk synth --context stage=prod --no-staging` |
 
 ビルド成果物（CloudFormation テンプレート）は `cdk-out` アーティファクトとして 7 日間保存されます。
 

--- a/docs/docs/development/github-workflow.mdx
+++ b/docs/docs/development/github-workflow.mdx
@@ -68,6 +68,59 @@ GitHub Actions で以下のワークフローが自動実行されます。
 | Prettier   | `npm run format:check` |
 | ビルド     | `npm run build`        |
 
+### CDK CI
+
+ファイル: `.github/workflows/cdk-ci.yml`
+
+**トリガー**: `infra/**`（ただし `infra/lambda/**` を除く）に変更を含む push または PR（対象ブランチ: `main`, `develop`）
+
+| ステップ                 | コマンド               |
+| ------------------------ | ---------------------- |
+| 型チェック               | `npx tsc --noEmit`     |
+| Prettier                 | `npm run format:check` |
+| ESLint                   | `npm run lint`         |
+| ビルド                   | `npm run build`        |
+| CDK Synth（dev 環境）    | `npx cdk synth --context stage=dev --no-staging` |
+| CDK Synth（prod 環境）   | `npx cdk synth --context stage=prod --no-staging` |
+
+ビルド成果物（CloudFormation テンプレート）は `cdk-out` アーティファクトとして 7 日間保存されます。
+
+### Docs CI
+
+ファイル: `.github/workflows/docs-ci.yml`
+
+**トリガー**: `docs/**` に変更を含む push または PR（対象ブランチ: `main`, `develop`）
+
+| ステップ             | コマンド               |
+| -------------------- | ---------------------- |
+| フォーマットチェック | `bun run format:check` |
+| Docusaurus ビルド    | `bun run build`        |
+
+ドキュメントサイトのビルドには [Bun](https://bun.sh/) を使用します（Node.js / npm ではありません）。
+
+### Docs Deploy
+
+ファイル: `.github/workflows/docs-deploy.yml`
+
+**トリガー**: `docs/**` に変更を含む `main` ブランチへの push（または手動実行 `workflow_dispatch`）
+
+`main` ブランチへのマージ後、Docusaurus ドキュメントサイトを自動的に **GitHub Pages** へデプロイします。
+CI（Docs CI）とは別ワークフローで、`main` push 時のみデプロイが走ります。
+
+### Update Docs（エージェントワークフロー）
+
+ファイル: `.github/workflows/update-docs.lock.yml`
+
+**トリガー**: `main` ブランチへの push（または手動実行 `workflow_dispatch`）
+
+AI エージェントがコードの差分を分析し、必要なドキュメント更新を検出して**ドラフト PR** を自動生成します。
+設定ファイル: `.github/workflows/update-docs.md`
+
+:::note
+Update Docs ワークフローはコード変更がドキュメントに反映されているかを継続的にチェックします。
+ドキュメント更新が必要な場合は、自動的にドラフト PR が作成されます。
+:::
+
 ## ローカル Git フック（lefthook）
 
 [lefthook](https://github.com/evilmartians/lefthook) を使い、CI と同等のチェックをローカルで事前実行します。


### PR DESCRIPTION
- github-workflow.mdx に CDK CI・Docs CI・Docs Deploy・Update Docs の 各ワークフロー説明を追加（これまで Frontend CI と Lambda CI のみ記載）
- deployment/backend.md の「CDK アプリ実装が存在しない」という記述を修正 （infra/lib/cooking-planner-stack.ts に DynamoDB テーブル定義が既に存在するため）
