### PR TITLE
fix: add vulnerability-alerts: read permission to run-update-docs job

### DIFF
--- a/.github/workflows/update-docs-trigger.yml
+++ b/.github/workflows/update-docs-trigger.yml
@@ -53,5 +53,6 @@ jobs:
       repository-projects: read
       security-events: read
       statuses: read
+      vulnerability-alerts: read
     uses: ./.github/workflows/update-docs.lock.yml
     secrets: inherit


### PR DESCRIPTION
The nested 'agent' job in update-docs.lock.yml requests
'vulnerability-alerts: read' via 'permissions: read-all', but the
calling job in update-docs-trigger.yml did not grant this permission,
causing it to default to 'none' and fail validation.

https://claude.ai/code/session_01WrfDq8UTGhHbqKyQtTqmmW