### PR TITLE
Cloudflare Tunnel設定を追加し外部公開できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ docs/build
 docs/node_modules
 docs/package-lock.json
 backend/package-lock.json
+
+# Cloudflare Tunnel local credentials and copied runtime config
+/cloudflare/config.yml
+/cloudflare/*.json
+/cloudflare/cert.pem
+/.cloudflared/

--- a/cloudflare/config.yml.example
+++ b/cloudflare/config.yml.example
@@ -1,5 +1,7 @@
 # Copy this file to your cloudflared config location, then replace every
-# placeholder with values from `cloudflared tunnel create <NAME>`.
+# placeholder: TUNNEL_UUID and the credentials JSON path come from the
+# output of `cloudflared tunnel create <NAME>`; APP_HOSTNAME is the domain
+# you want to expose (e.g. cooking.example.com).
 #
 # Default config locations:
 # - Windows: %USERPROFILE%\.cloudflared\config.yml

--- a/cloudflare/config.yml.example
+++ b/cloudflare/config.yml.example
@@ -1,0 +1,15 @@
+# Copy this file to your cloudflared config location, then replace every
+# placeholder with values from `cloudflared tunnel create <NAME>`.
+#
+# Default config locations:
+# - Windows: %USERPROFILE%\.cloudflared\config.yml
+# - macOS/Linux: ~/.cloudflared/config.yml
+
+tunnel: <TUNNEL_UUID>
+credentials-file: <ABSOLUTE_PATH_TO_TUNNEL_CREDENTIALS_JSON>
+
+ingress:
+  - hostname: <APP_HOSTNAME>
+    service: http://127.0.0.1:3000
+
+  - service: http_status:404

--- a/docs/docs/deployment/cloudflare-tunnel.md
+++ b/docs/docs/deployment/cloudflare-tunnel.md
@@ -1,0 +1,221 @@
+---
+id: deployment-cloudflare-tunnel
+title: Cloudflare Tunnel
+sidebar_position: 4
+---
+
+## 概要
+
+Cloudflare Tunnel を使い、ローカル PC 上で動く Hono サーバーをインターネットへ公開する。
+外部からのアクセスは Cloudflare Access のメール認証ポリシーで制御し、自分のメールアドレスだけを許可する。
+
+この手順では、リポジトリに含まれる `cloudflare/config.yml.example` をテンプレートとして使う。
+実際の Tunnel UUID、認証情報 JSON、`cert.pem` はコミットしない。
+
+---
+
+## 前提条件
+
+- Cloudflare アカウントと、Cloudflare に登録済みのドメインがあること
+- ローカル PC でアプリを `http://127.0.0.1:3000` として起動できること
+- Hono サーバーは `127.0.0.1` に bind し、LAN に直接公開しないこと
+- Cloudflare Access で許可する自分のメールアドレスが決まっていること
+
+---
+
+## 1. cloudflared をインストールする
+
+Cloudflare の公式ダウンロードページから、利用 OS に合う `cloudflared` をインストールする。
+
+- Windows: GitHub Releases の MSI または実行ファイルを使う
+- macOS: `brew install cloudflared`
+- Linux: Cloudflare Package Repository または GitHub Releases の `.deb` / `.rpm` / binary を使う
+
+インストール後にバージョンを確認する。
+
+```bash
+cloudflared --version
+```
+
+---
+
+## 2. Cloudflare にログインする
+
+`cloudflared` から Cloudflare アカウントへログインする。
+
+```bash
+cloudflared tunnel login
+```
+
+ブラウザが開くので、Cloudflare アカウントでログインし、対象ドメインを選択する。
+成功すると既定の cloudflared ディレクトリに `cert.pem` が作成される。
+
+---
+
+## 3. Tunnel を作成する
+
+Tunnel 名はわかりやすい名前にする。
+
+```bash
+cloudflared tunnel create cooking-planner
+```
+
+出力された Tunnel UUID と credentials file のパスを控える。
+作成結果は次のコマンドでも確認できる。
+
+```bash
+cloudflared tunnel list
+```
+
+---
+
+## 4. 設定ファイルを作成する
+
+テンプレートを cloudflared の設定場所へコピーする。
+
+```bash
+# Windows PowerShell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.cloudflared"
+Copy-Item cloudflare/config.yml.example "$env:USERPROFILE\.cloudflared\config.yml"
+
+# macOS / Linux
+mkdir -p ~/.cloudflared
+cp cloudflare/config.yml.example ~/.cloudflared/config.yml
+```
+
+コピーした `config.yml` を編集し、以下を実値に置き換える。
+
+| プレースホルダ                               | 設定する値                                           |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `<TUNNEL_UUID>`                              | `cloudflared tunnel create` で発行された Tunnel UUID |
+| `<ABSOLUTE_PATH_TO_TUNNEL_CREDENTIALS_JSON>` | Tunnel credentials JSON の絶対パス                   |
+| `<APP_HOSTNAME>`                             | 公開するホスト名（例: `cooking.example.com`）        |
+
+設定例:
+
+```yaml
+tunnel: 00000000-0000-0000-0000-000000000000
+credentials-file: C:\Users\your-name\.cloudflared\00000000-0000-0000-0000-000000000000.json
+
+ingress:
+  - hostname: cooking.example.com
+    service: http://127.0.0.1:3000
+
+  - service: http_status:404
+```
+
+:::caution
+`credentials-file` に指定する JSON と `cert.pem` は認証情報である。
+リポジトリ配下へコピーした場合もコミットしない。
+:::
+
+---
+
+## 5. DNS ルートを作成する
+
+公開ホスト名を Tunnel に紐付ける。
+
+```bash
+cloudflared tunnel route dns cooking-planner cooking.example.com
+```
+
+このコマンドにより、対象ホスト名から Tunnel への CNAME レコードが作成される。
+
+---
+
+## 6. Cloudflare Access を設定する
+
+Cloudflare Zero Trust ダッシュボードで Access Application を作成する。
+
+1. Cloudflare dashboard で `Zero Trust > Access controls > Applications` を開く
+2. `Create new application` を選ぶ
+3. `Self-hosted and private` を選ぶ
+4. `Add public hostname` で `<APP_HOSTNAME>` と同じホスト名を指定する
+5. Access policy で Allow policy を作成または選択する
+6. Include ルールで自分のメールアドレスだけを許可する
+7. 認証方法は One-time PIN または利用中の IdP を選ぶ
+
+Cloudflare Access Application は既定で deny になり、Allow policy に一致したユーザーだけがアクセスできる。
+
+---
+
+## 7. Tunnel を起動する
+
+先にアプリを起動する。
+
+```bash
+bun run build:all
+bun run backend:start
+```
+
+別ターミナルで Tunnel を起動する。
+
+```bash
+cloudflared tunnel run cooking-planner
+```
+
+設定ファイルを既定の場所に置かない場合は `--config` を指定する。
+
+```bash
+cloudflared tunnel --config /path/to/config.yml run cooking-planner
+```
+
+systemd / Windows service / launch agent としての常駐登録はこの Issue の対象外。
+必要になったら Cloudflare の service 登録手順に従って追加する。
+
+---
+
+## 8. 動作確認
+
+### 許可ユーザーで確認する
+
+1. スマホまたは別ネットワークの端末から `https://<APP_HOSTNAME>` を開く
+2. Cloudflare Access の認証画面に遷移することを確認する
+3. 許可したメールアドレスで認証する
+4. Cooking Planner の画面が表示されることを確認する
+
+### 未許可ユーザーで確認する
+
+1. Access policy に含めていないメールアドレスで認証を試す
+2. アプリ画面に到達できないことを確認する
+
+### Tunnel 設定を確認する
+
+```bash
+cloudflared tunnel ingress validate
+cloudflared tunnel ingress rule https://<APP_HOSTNAME>
+cloudflared tunnel info cooking-planner
+```
+
+`ingress rule` の結果が `service: http://127.0.0.1:3000` に一致していれば、公開ホスト名からローカル Hono サーバーへ転送される。
+
+---
+
+## トラブルシューティング
+
+### Access 認証後に 502 / 1033 になる
+
+- Hono サーバーが起動しているか確認する
+- `config.yml` の `service` が `http://127.0.0.1:3000` になっているか確認する
+- Hono サーバーの `PORT` と Tunnel の転送先ポートが一致しているか確認する
+
+### 認証画面が出ずにアプリへ到達する
+
+- Access Application の hostname が `<APP_HOSTNAME>` と一致しているか確認する
+- Access policy が Bypass になっていないか確認する
+- ローカルサーバーを `0.0.0.0` で公開していないか確認する
+
+### `cloudflared tunnel run` が設定ファイルを見つけられない
+
+- `config.yml` が既定の cloudflared ディレクトリにあるか確認する
+- 別の場所に置いた場合は `--config` で明示する
+- `credentials-file` は絶対パスで指定する
+
+---
+
+## 参考
+
+- [Cloudflare Tunnel downloads](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/)
+- [Create a locally-managed tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/create-local-tunnel/)
+- [Cloudflare Tunnel configuration file](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/configuration-file/)
+- [Publish a self-hosted application to the Internet](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/)

--- a/docs/docs/deployment/cloudflare-tunnel.md
+++ b/docs/docs/deployment/cloudflare-tunnel.md
@@ -71,7 +71,7 @@ cloudflared tunnel list
 
 ## 4. 設定ファイルを作成する
 
-テンプレートを cloudflared の設定場所へコピーする。
+テンプレートを cloudflared の設定場所へコピーする。以下のコマンドはリポジトリ root で実行する。
 
 ```bash
 # Windows PowerShell
@@ -141,7 +141,7 @@ Cloudflare Access Application は既定で deny になり、Allow policy に一�
 
 ## 7. Tunnel を起動する
 
-先にアプリを起動する。
+先にアプリを起動する。以下のコマンドはリポジトリ root で実行する。
 
 ```bash
 bun run build:all


### PR DESCRIPTION
## 概要（必須）
- このPRの目的：Cloudflare Tunnel の設定テンプレートとセットアップ手順を追加し、自宅PC上のサーバーを Cloudflare Access 経由で公開できるようにする
- 主な変更点：`cloudflare/config.yml.example` の追加、Cloudflare Tunnel 手順ドキュメントの追加、cloudflared 認証情報の `.gitignore` 追加
- ユーザーに見える変更：あり / `docs/docs/deployment/cloudflare-tunnel.md` に外部公開手順が追加される

## 背景 / 関連（必須）
- 関連Issue/タスク：closes #132
- 参照ドキュメント（docs/*.md）：
    - docs/01-vision-and-scope.md（該当箇所：Cloudflare Access と Cloudflare Tunnel による外部公開方針）
    - docs/02-features-and-screens.md（該当画面：ログイン画面 / Cloudflare Access 認証）
    - docs/03-domain-and-data-model.md（該当モデル/テーブル：該当なし）
    - docs/04-api-design.md（該当エンドポイント：Cloudflare Access 前提の共通認証）
    - docs/05-architecture-notes.md（該当事項：Cloudflare Tunnel / Access、127.0.0.1 bind）

## 変更内容（必須）
- フロントエンド：
    - 追加/変更した画面・コンポーネント：該当なし
    - API 呼び出し（features/<domain>/api/*.ts）の追加/変更：該当なし
    - React Query フック（hooks/use*.ts）の追加/変更：該当なし
- バックエンド（Lambda）：
    - エンドポイント（パス + メソッド）：該当なし
    - DynamoDB 操作（テーブル・PK/SK・GSI 等）：該当なし
    - レスポンス形式（docs/04 に準拠）：該当なし
- インフラ（CDK）：
    - 追加/変更したリソース：該当なし
    - 環境変数・権限（IAM）：該当なし

## 仕様との整合性（必須）
- どの仕様に基づいているか：docs/01 と docs/05 の Cloudflare Tunnel / Cloudflare Access 方針、Issue #132 の受け入れ条件
- 仕様との差分がある場合：Cloudflare アカウント操作、DNS、Access policy 作成は手順化のみで、認証情報や実環境値はコミットしない

## 影響範囲（必須）
- フロントエンド：なし
- バックエンド：なし
- データ：なし
- 認証/認可：Cloudflare Access の Allow policy をメールアドレス許可リストで設定する手順を追加
- インフラ/コスト：CDK 差分なし。Cloudflare Tunnel / Access は個人利用の無料プラン範囲を想定

## 移行・リリース・ロールバック（必要な場合）
- データ移行/バックフィル：該当なし
- フィーチャーフラグ/段階的リリース：該当なし
- ロールバック方針（戻し方を1行で）：このPRのコミットを revert する

## 動作確認 / テスト（必須）
- 確認環境：開発
- 手動確認手順：
    1. `cloudflare/config.yml.example` に Tunnel UUID / credentials path / hostname のプレースホルダがあることを確認
    2. `docs/docs/deployment/cloudflare-tunnel.md` にインストール、Tunnel 作成、DNS route、Access policy、起動、検証手順があることを確認
- 期待結果：Issue #132 の受け入れ条件を満たすテンプレートと手順が存在する
- 追加したテスト：該当なし（ドキュメントと設定テンプレートのみ）
- 既存テストへの影響：なし

## スクリーンショット / 動画（UI変更がある場合）
該当なし

## 破壊的変更
- なし

---

## チェックリスト（全て日本語で記載すること）
- [x] すべての記述（タイトル/本文/コメント/チェックリスト等）は日本語で記載した
- [x] 対応する Issue を起点に作業し、必要なラベルを設定した
- [x] 変更は小さめで、スコープが明確（関係ない整形を混ぜない）
- [x] 関連する docs/*.md を確認し、実装はドキュメントを優先した
- [x] 仕様とコードに齟齬がある場合の判断/補足を本文に記載した（必要ならIssue化）

### フロントエンド
- [x] API呼び出しは fetch 直叩きせず、lib/apiClient.ts 経由（該当なし）
- [x] features/<domain>/api/*.ts にラッパーを追加/更新（該当なし）
- [x] React Query のカスタムフック（hooks/use*.ts）を用意/更新（該当なし）
- [x] 未ログイン時の挙動が既存方針（例：/login リダイレクト）に反しない（該当なし）

### バックエンド（Lambda）
- [x] API Gateway イベントを直接ハンドリングし、軽量な自前ルーティングを使用（Express等は未導入）（該当なし）
- [x] DynamoDB のキー条件にユーザー識別子を含める（原則：Cognito sub）（該当なし）
- [x] レスポンスは docs/04-api-design.md のエラー形式（statusCode, error.code, error.message）に準拠（該当なし）
- [x] @aws-sdk v3 を使用（該当なし）

### データ/インフラ
- [x] DynamoDB テーブル/インデックス変更は docs/03 と整合（該当なし）
- [x] CDK のリソース名・環境変数命名は docs/05 に準拠（該当なし）
- [x] IAM 権限は最小権限（該当なし）

### 品質
- [x] ESLint / 型チェックを通過
- [ ] コンソールエラー/警告を解消（既存の Vite Node.js バージョン警告と Docusaurus 警告あり）
- [x] パフォーマンス/コストに影響しうる点を本文に明記
- [x] セキュリティ（認証/認可/入力バリデーション/秘匿情報）を確認

### ドキュメント/運用
- [x] AGENTS.md の更新が必要な変更なら反映した（該当なし）
- [x] README や docs の更新が必要なら反映
- [x] 動作確認手順と期待結果を本文に明記
- [x] UI変更はスクショ/動画を添付（該当なし）

## ローカル確認
- `bun run lint`：成功
- `bun run type-check`：成功
- `bun run build:all`：成功（Node.js 20.18.0 に対する Vite のバージョン警告あり）
- `bun run docs:build`：成功（既存の Docusaurus 警告あり）
- `cd docs && bunx prettier --check docs/deployment/cloudflare-tunnel.md`：成功
- `bun run format:check`：失敗（既存フロントエンド 25 ファイルの未整形。今回追加ファイルは単体チェック済み）