### PR TITLE
バックエンドテストの並列実行タイムアウトを解消する

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,42 +1,6 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { installBunStaticShim } from './test-utils/bun-static-shim';
-
-const originalFrontendDistDir = process.env.FRONTEND_DIST_DIR;
-
-let frontendDistDir: string;
-let app: (typeof import('./app'))['default'];
-
-beforeAll(async () => {
-  installBunStaticShim();
-
-  frontendDistDir = await mkdtemp(join(tmpdir(), 'cooking-planner-frontend-dist-'));
-  const assetsDir = join(frontendDistDir, 'assets');
-
-  await mkdir(assetsDir, { recursive: true });
-  await writeFile(
-    join(frontendDistDir, 'index.html'),
-    '<!doctype html><html><body><div id="root">Cooking Planner</div></body></html>'
-  );
-  await writeFile(join(assetsDir, 'app.js'), 'console.log("cooking planner");');
-
-  process.env.FRONTEND_DIST_DIR = frontendDistDir;
-  ({ default: app } = await import('./app'));
-});
-
-afterAll(async () => {
-  if (originalFrontendDistDir === undefined) {
-    delete process.env.FRONTEND_DIST_DIR;
-  } else {
-    process.env.FRONTEND_DIST_DIR = originalFrontendDistDir;
-  }
-
-  if (frontendDistDir) {
-    await rm(frontendDistDir, { recursive: true, force: true });
-  }
-});
+import { describe, expect, it } from 'vitest';
+// Bun シムと FRONTEND_DIST_DIR は test-utils/vitest.setup.ts で準備済み
+import app from './app';
 
 describe('app route prefixes', () => {
   it('/api prefix でも health endpoint を公開する', async () => {

--- a/backend/src/menus/updateMenu.test.ts
+++ b/backend/src/menus/updateMenu.test.ts
@@ -1,5 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { installBunStaticShim } from '../test-utils/bun-static-shim';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { updateMenuForUserMock } = vi.hoisted(() => ({
   updateMenuForUserMock: vi.fn(),
@@ -18,12 +17,7 @@ vi.mock('../shared/auth', () => ({
   getUserId: () => 'user-123',
 }));
 
-let app: (typeof import('../app'))['default'];
-
-beforeAll(async () => {
-  installBunStaticShim();
-  ({ default: app } = await import('../app'));
-});
+import app from '../app';
 
 const MENU_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 

--- a/backend/src/recipes/getRecipeById.test.ts
+++ b/backend/src/recipes/getRecipeById.test.ts
@@ -1,5 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { installBunStaticShim } from '../test-utils/bun-static-shim';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { findRecipeWithIngredientsMock } = vi.hoisted(() => ({
   findRecipeWithIngredientsMock: vi.fn(),
@@ -17,12 +16,7 @@ vi.mock('../shared/auth', () => ({
   getUserId: () => 'user-123',
 }));
 
-let app: (typeof import('../app'))['default'];
-
-beforeAll(async () => {
-  installBunStaticShim();
-  ({ default: app } = await import('../app'));
-});
+import app from '../app';
 
 describe('GET /api/recipes/:recipeId', () => {
   beforeEach(() => {

--- a/backend/src/shoppingList/getShoppingList.test.ts
+++ b/backend/src/shoppingList/getShoppingList.test.ts
@@ -1,5 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { installBunStaticShim } from '../test-utils/bun-static-shim';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { listMenusInRangeMock, findRecipeWithIngredientsMock } = vi.hoisted(() => ({
   listMenusInRangeMock: vi.fn(),
@@ -26,12 +25,7 @@ vi.mock('../shared/auth', () => ({
   getUserId: () => 'user-123',
 }));
 
-let app: (typeof import('../app'))['default'];
-
-beforeAll(async () => {
-  installBunStaticShim();
-  ({ default: app } = await import('../app'));
-});
+import app from '../app';
 
 const getShoppingListRequest = (from: string, to: string): Promise<Response> =>
   app.request(`/api/shopping-list?from=${from}&to=${to}`);

--- a/backend/src/test-utils/vitest.setup.ts
+++ b/backend/src/test-utils/vitest.setup.ts
@@ -8,6 +8,8 @@ import { installBunStaticShim } from './bun-static-shim';
 // テストファイルの読み込み前（setupFiles 実行時）に準備する。
 installBunStaticShim();
 
+const originalFrontendDistDir = process.env.FRONTEND_DIST_DIR;
+
 const frontendDistDir = await mkdtemp(join(tmpdir(), 'cooking-planner-frontend-dist-'));
 const assetsDir = join(frontendDistDir, 'assets');
 
@@ -21,5 +23,11 @@ await writeFile(join(assetsDir, 'app.js'), 'console.log("cooking planner");');
 process.env.FRONTEND_DIST_DIR = frontendDistDir;
 
 afterAll(async () => {
+  if (originalFrontendDistDir === undefined) {
+    delete process.env.FRONTEND_DIST_DIR;
+  } else {
+    process.env.FRONTEND_DIST_DIR = originalFrontendDistDir;
+  }
+
   await rm(frontendDistDir, { recursive: true, force: true });
 });

--- a/backend/src/test-utils/vitest.setup.ts
+++ b/backend/src/test-utils/vitest.setup.ts
@@ -1,0 +1,25 @@
+import { afterAll } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installBunStaticShim } from './bun-static-shim';
+
+// app モジュールは import 時に Bun グローバルと FRONTEND_DIST_DIR を参照するため、
+// テストファイルの読み込み前（setupFiles 実行時）に準備する。
+installBunStaticShim();
+
+const frontendDistDir = await mkdtemp(join(tmpdir(), 'cooking-planner-frontend-dist-'));
+const assetsDir = join(frontendDistDir, 'assets');
+
+await mkdir(assetsDir, { recursive: true });
+await writeFile(
+  join(frontendDistDir, 'index.html'),
+  '<!doctype html><html><body><div id="root">Cooking Planner</div></body></html>'
+);
+await writeFile(join(assetsDir, 'app.js'), 'console.log("cooking planner");');
+
+process.env.FRONTEND_DIST_DIR = frontendDistDir;
+
+afterAll(async () => {
+  await rm(frontendDistDir, { recursive: true, force: true });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./src/test-utils/vitest.setup.ts'],
+  },
+});


### PR DESCRIPTION
## 概要（必須）
- このPRの目的：バックエンドVitestスイートの並列実行時に `beforeAll` が10秒でタイムアウトする問題を解消する
- 主な変更点：テストの `beforeAll` 内で行っていた `await import('../app')`（動的import）を静的importに変更し、Bunシムとフロント配布ディレクトリの準備を vitest の setupFiles に集約
- ユーザーに見える変更：なし（テスト基盤のみの変更）

## 背景 / 関連（必須）
- 関連Issue/タスク：closes #146
- 参照ドキュメント（docs/*.md）：該当なし（テスト基盤のみの変更）

## 変更内容（必須）
- フロントエンド：該当なし
- バックエンド（Bun + Hono）：
    - エンドポイント（パス + メソッド）：変更なし
    - PostgreSQL 操作：変更なし
    - レスポンス形式：変更なし
    - テスト基盤：
        - `backend/vitest.config.ts` を新規追加（setupFiles を設定）
        - `backend/src/test-utils/vitest.setup.ts` を新規追加（Bunシムのインストールと FRONTEND_DIST_DIR の準備をテストファイル読み込み前に実施）
        - `app.test.ts` / `recipes/getRecipeById.test.ts` / `menus/updateMenu.test.ts` / `shoppingList/getShoppingList.test.ts` の `beforeAll` 内動的importを静的importへ変更
- 公開/認証：該当なし

## 仕様との整合性（必須）
- どの仕様に基づいているか：Issue #146 の受け入れ条件（オプションなしで `bun run test` が安定して成功する）
- 仕様との差分がある場合：該当なし

## 影響範囲（必須）
- フロントエンド：影響なし
- バックエンド：プロダクションコードの変更なし。テストの実行経路のみ変更
- データ：影響なし
- 認証/認可：影響なし
- 公開/運用コスト：影響なし

## 移行・リリース・ロールバック（必要な場合）
- ロールバック方針：本PRをrevertするのみ

## 動作確認 / テスト（必須）
- 確認環境：開発（ローカル Windows）
- 手動確認手順：
    1. `cd backend && bun run test` をウォーム/コールドキャッシュ双方で複数回実行
    2. リポジトリルートで `bun run lint && bun run format:check && bun run type-check && bun run build:all` を実行
- 期待結果：6ファイル・27テストが毎回タイムアウトなしで成功し、lint/型チェック/ビルドも成功する（計12回実行しすべて成功を確認）
- 追加したテスト：なし（既存27テストの安定化）
- 既存テストへの影響：テスト内容・アサーションは変更なし。初期化経路のみ変更

## 破壊的変更
- なし

---

## チェックリスト（全て日本語で記載すること）
- [x] すべての記述（タイトル/本文/コメント/チェックリスト等）は日本語で記載した
- [x] 対応する Issue を起点に作業し、必要なラベルを設定した
- [x] 変更は小さめで、スコープが明確（関係ない整形を混ぜない）
- [x] 関連する docs/*.md を確認し、実装はドキュメントを優先した
- [x] 仕様とコードに齟齬がある場合の判断/補足を本文に記載した（必要ならIssue化）

### フロントエンド
- 該当なし

### バックエンド（Bun + Hono）
- [x] Hono のルーティング・ミドルウェア構成に沿って実装（変更なし）
- 該当なし（DB・レスポンス形式の変更なし）

### データ/公開
- 該当なし

### 品質
- [x] ESLint / 型チェックを通過
- [x] コンソールエラー/警告を解消
- [x] パフォーマンス/コストに影響しうる点を本文に明記（影響なし）
- [x] セキュリティ（認証/認可/入力バリデーション/秘匿情報）を確認（影響なし）

### ドキュメント/運用
- [x] AGENTS.md の更新が必要な変更なら反映した（不要）
- [x] README や docs の更新が必要なら反映（不要）
- [x] 動作確認手順と期待結果を本文に明記
- 該当なし（UI変更なし）
